### PR TITLE
[MOBILESDK-223] - Values swapped in advanced settings screen after tapping on Save button

### DIFF
--- a/app/src/main/java/com/alfresco/dbp/sample/features/pkce/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/com/alfresco/dbp/sample/features/pkce/AdvancedSettingsFragment.kt
@@ -25,8 +25,8 @@ class AdvancedSettingsFragment : Fragment(R.layout.fragment_advanced_settings) {
         btnSave.setOnClickListener {
             mainViewModel.changeSettings(
                     tilRealm.editText?.text.toString(),
-                    tilRedirectUrl.editText?.text.toString(),
-                    tilClientId.editText?.text.toString())
+                    tilClientId.editText?.text.toString(),
+                    tilRedirectUrl.editText?.text.toString())
             findNavController().popBackStack()
         }
 


### PR DESCRIPTION
Seems like the values regarding the client id and the redirect url were swapped when passing them to the viewmodel and because of that the user gets an error from the server that the client id does not exist.