### PR TITLE
[MOBILESDK-222] - Sample app is crashing when pressing on Login after visiting advanced settings screen

### DIFF
--- a/app/src/main/java/com/alfresco/dbp/sample/common/Navigation.kt
+++ b/app/src/main/java/com/alfresco/dbp/sample/common/Navigation.kt
@@ -1,0 +1,33 @@
+package com.alfresco.dbp.sample.common
+
+import android.app.Activity
+import android.net.Uri
+import androidx.annotation.IdRes
+import androidx.fragment.app.Fragment
+import androidx.navigation.findNavController
+import androidx.navigation.fragment.findNavController
+
+/**
+ *
+ * Created by Bogdan Roatis on 24 Oct 2019.
+ */
+
+private const val NAVIGATION_BASE_PATH = "alfresco.sample://"
+
+enum class Screens(val uriPath: String) {
+    REFRESH("${NAVIGATION_BASE_PATH}refreshToken"),
+}
+
+fun Fragment.navigateToRefreshToken() {
+    navigate(Screens.REFRESH)
+}
+
+fun Activity.navigate(@IdRes viewId: Int, screen: Screens) {
+    val uri = Uri.parse(screen.uriPath)
+    findNavController(viewId).navigate(uri)
+}
+
+fun Fragment.navigate(screen: Screens) {
+    val uri = Uri.parse(screen.uriPath)
+    findNavController().navigate(uri)
+}

--- a/app/src/main/java/com/alfresco/dbp/sample/features/BaseFragment.kt
+++ b/app/src/main/java/com/alfresco/dbp/sample/features/BaseFragment.kt
@@ -9,6 +9,7 @@ import androidx.navigation.fragment.findNavController
 import com.alfresco.dbp.sample.MainViewModel
 import com.alfresco.dbp.sample.PkceAuthUiModel
 import com.alfresco.dbp.sample.R
+import com.alfresco.dbp.sample.common.navigateToRefreshToken
 import com.alfresco.dbp.sample.common.observe
 import kotlinx.android.synthetic.main.fragment_base.*
 
@@ -35,7 +36,7 @@ class BaseFragment : Fragment(R.layout.fragment_base) {
 
     private fun onResult(authUiModel: PkceAuthUiModel) {
         if (authUiModel.success) {
-            findNavController().navigate(BaseFragmentDirections.navigateToRefreshToken())
+            navigateToRefreshToken()
         } else {
             onError(authUiModel.error)
         }

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -5,20 +5,9 @@
     app:startDestination="@id/baseFragment">
 
     <fragment
-        android:id="@+id/basicAuthFragment"
-        android:name="com.alfresco.dbp.sample.features.basic.BasicAuthFragment"
-        android:label="BasicAuthFragment" >
-        <argument
-            android:name="url"
-            app:argType="string" />
-    </fragment>
-    <fragment
         android:id="@+id/baseFragment"
         android:name="com.alfresco.dbp.sample.features.BaseFragment"
-        android:label="BaseFragment" >
-        <action
-            android:id="@+id/action_baseFragment_to_basicAuthFragment"
-            app:destination="@id/basicAuthFragment" />
+        android:label="BaseFragment">
         <action
             android:id="@+id/navigateToAdvancedSettings"
             app:destination="@id/advancedSettingsFragment" />
@@ -33,5 +22,8 @@
     <fragment
         android:id="@+id/refreshTokenFragment"
         android:name="com.alfresco.dbp.sample.features.pkce.RefreshTokenFragment"
-        android:label="RefreshTokenFragment" />
+        android:label="RefreshTokenFragment" >
+
+        <deepLink app:uri="alfresco.sample://refreshToken" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
Apparently there's some sort of an issue when trying to navigate with an already defined action while coming back from another activity. Just to elaborate, we have the main activity inside the sample app, but when trying to auth the user, we're starting another activity that contains the webview (this is inside the auth sdk). When coming back from that activity the navigation component doesn't seem to find the defined navigation action. As a fast workaround for this, I'm using deeplinks instead of statically defined navigation actions.