### PR TITLE
Bump compileSdk/targetSdk to 36 (AGP 8.10 + Gradle 8.11.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 18
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 18
+          distribution: temurin
+          java-version: '17'
 
       - uses: actions/cache@v3
         name: Cache gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Set up JDK 18
+        uses: actions/setup-java@v1
         with:
-          distribution: temurin
-          java-version: '17'
+          java-version: 18
 
       - uses: actions/cache@v3
         name: Cache gradle

--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,11 @@ subprojects {
     afterEvaluate {
         if(it.hasProperty('android')) {
             android {
-                compileSdkVersion 35
+                compileSdkVersion 36
 
                 defaultConfig {
                     minSdkVersion 24
-                    targetSdkVersion 34
+                    targetSdkVersion 36
                 }
                 compileOptions {
                     sourceCompatibility JavaVersion.VERSION_17

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ alfresco-contentKtx = "com.alfresco.android:content-ktx:0.3.3-SNAPSHOT"
 alfresco-process = "com.alfresco.android:process:0.1.4-SNAPSHOT"
 
 android-desugar = "com.android.tools:desugar_jdk_libs:2.1.4"
-android-gradle = "com.android.tools.build:gradle:8.7.3"
+android-gradle = "com.android.tools.build:gradle:8.10.0"
 
 androidx-activity = "androidx.activity:activity-ktx:1.10.0"
 androidx-appcompat = "androidx.appcompat:appcompat:1.7.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jun 18 20:47:24 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
Toolchain bump so the app targets **Android 16 (API 36)** ahead of Google Play's requirement that apps targeting Android 15+ support API 36. Stays on the AGP 8.x line to avoid the AGP 9 major migration.

Tracking: **MOB-5879** · Epic: **ADST-876**

## Changes
- `build.gradle`: `compileSdkVersion 36`, `targetSdkVersion 36` (minSdk unchanged at 24)
- `gradle/libs.versions.toml`: AGP `8.7.3` → `8.10.0` (min AGP whose max supported API is 36)
- `gradle/wrapper/gradle-wrapper.properties`: Gradle `8.9` → `8.11.1` (required by AGP 8.10)

No `android.suppressUnsupportedCompileSdk` flag needed — AGP 8.10 officially supports API 36.

## Verification
- `./gradlew :app:assembleDebug` — **BUILD SUCCESSFUL** against API 36 on AGP 8.10.0 / Gradle 8.11.1. No unsupported-compileSdk warning.

## Notes
- Building now requires JDK 17–23 (Gradle 8.11.1 does not support JDK 24+). CI is already pinned to a compatible JDK.
- Kotlin 2.0.20 / KSP unchanged; SDK Build Tools 36.0.0 is AGP 8.10's default.
- Pre-existing deprecation warnings (`onBackPressed()`, `buildFeatures.buildConfig`) are out of scope and tracked separately.
- CI JDK modernization (`setup-java@v4` + Temurin 17) intentionally left out of this PR to keep it focused; it will be tracked separately.