### PR TITLE
MOB-5880: Handle edge-to-edge insets for API 36 enforcement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 18
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 18
+          distribution: temurin
+          java-version: '17'
 
       - uses: actions/cache@v3
         name: Cache gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Set up JDK 18
+        uses: actions/setup-java@v1
         with:
-          distribution: temurin
-          java-version: '17'
+          java-version: 18
 
       - uses: actions/cache@v3
         name: Cache gradle

--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,11 @@ subprojects {
     afterEvaluate {
         if(it.hasProperty('android')) {
             android {
-                compileSdkVersion 35
+                compileSdkVersion 36
 
                 defaultConfig {
                     minSdkVersion 24
-                    targetSdkVersion 34
+                    targetSdkVersion 36
                 }
                 compileOptions {
                     sourceCompatibility JavaVersion.VERSION_17

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ alfresco-contentKtx = "com.alfresco.android:content-ktx:0.3.3-SNAPSHOT"
 alfresco-process = "com.alfresco.android:process:0.1.4-SNAPSHOT"
 
 android-desugar = "com.android.tools:desugar_jdk_libs:2.1.4"
-android-gradle = "com.android.tools.build:gradle:8.7.3"
+android-gradle = "com.android.tools.build:gradle:8.10.0"
 
 androidx-activity = "androidx.activity:activity-ktx:1.10.0"
 androidx-appcompat = "androidx.appcompat:appcompat:1.7.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jun 18 20:47:24 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/theme/src/main/res/values-night-v35/themes.xml
+++ b/theme/src/main/res/values-night-v35/themes.xml
@@ -10,6 +10,7 @@
         <!-- System bars -->
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLightStatusBar">false</item>
+        <item name="android:fitsSystemWindows">true</item>
 
     </style>
 </resources>

--- a/theme/src/main/res/values-v35/themes.xml
+++ b/theme/src/main/res/values-v35/themes.xml
@@ -6,6 +6,7 @@
         <item name="android:statusBarColor">@android:color/white</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+        <item name="android:fitsSystemWindows">true</item>
 
     </style>
 </resources>


### PR DESCRIPTION
## Summary

Handles the edge-to-edge display enforcement that Android 16 (API 36) applies to apps targeting SDK 36. When targeting 36, `android:windowOptOutEdgeToEdgeEnforcement` is ignored, so the system draws content behind the status/navigation bars. Without inset handling, the toolbar/search bar overlaps the status bar and the bottom navigation overlaps the gesture area.

## Change

Adds `android:fitsSystemWindows="true"` to the two `-v35` themes so the content is inset below the system bars:

- `theme/src/main/res/values-v35/themes.xml` — `Base.Theme.Alfresco` (light)
- `theme/src/main/res/values-night-v35/themes.xml` — `Theme.Alfresco` (dark)

2 files changed, 2 insertions.

## Why `-v35`

- Edge-to-edge enforcement begins at API 35 (for apps targeting SDK 35+); the `-v35` qualifier covers API 35 **and higher** (35, 36, …).
- Consistent with the module's existing versioned-theme pattern (`-v23`, `-v27`, `-v35`).
- Harmless on API 35 (where `windowOptOutEdgeToEdgeEnforcement` is still honored); does the actual work on API 36 where the opt-out is ignored.

## Verification

Built with SDK 36 and installed on an API 36 / Android 16 emulator (16 KB page size). Confirmed on the main screen in **both light and dark** modes:
- Toolbar/search bar padded below the status bar — no overlap.
- Bottom navigation sits above the gesture pill — no overlap.

## Notes

- Stacked on top of #389 (MOB-5879 toolchain + SDK 36 upgrade); base branch is `mob-5879-android-targetsdk-36` to keep the diff minimal.
- The now-deprecated `windowOptOutEdgeToEdgeEnforcement` item is intentionally retained to minimize the change (still honored on API 35).
- A full programmatic per-view inset migration (`WindowInsetsCompat`) is the longer-term "textbook" approach and is better tracked as a separate follow-up.