### PR TITLE
MOB-5902: Update copyright year 2025 → 2026 on login/auth screens

### DIFF
--- a/auth/src/main/res/values-de/strings.xml
+++ b/auth/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="auth_app_name">Auth Library</string>
-    <string name="auth_copyright_notice">© 2025 Hyland Software, Inc. und Tochtergesellschaften. Alle Rechte vorbehalten.</string>
+    <string name="auth_copyright_notice">© 2026 Hyland Software, Inc. und Tochtergesellschaften. Alle Rechte vorbehalten.</string>
 
     <string name="auth_connect_field_hint">Verbinden mit</string>
     <string name="auth_connect_button">Verbinden</string>

--- a/auth/src/main/res/values-es/strings.xml
+++ b/auth/src/main/res/values-es/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="auth_app_name">Auth Library</string>
-    <string name="auth_copyright_notice">© 2025 Hyland Software, Inc. y sus afiliados. Todos los derechos reservados.</string>
+    <string name="auth_copyright_notice">© 2026 Hyland Software, Inc. y sus afiliados. Todos los derechos reservados.</string>
 
     <string name="auth_connect_field_hint">Conectar a</string>
     <string name="auth_connect_button">Conectar</string>

--- a/auth/src/main/res/values-fr/strings.xml
+++ b/auth/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="auth_app_name">Auth Library</string>
-    <string name="auth_copyright_notice">© 2025 Hyland Software, Inc. et ses filiales. Tous droits réservés.</string>
+    <string name="auth_copyright_notice">© 2026 Hyland Software, Inc. et ses filiales. Tous droits réservés.</string>
 
     <string name="auth_connect_field_hint">Connexion à</string>
     <string name="auth_connect_button">Connexion</string>

--- a/auth/src/main/res/values-it/strings.xml
+++ b/auth/src/main/res/values-it/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="auth_app_name">Auth Library</string>
-    <string name="auth_copyright_notice">© 2025 Hyland Software, Inc. e sue affiliate. Tutti i diritti riservati.</string>
+    <string name="auth_copyright_notice">© 2026 Hyland Software, Inc. e sue affiliate. Tutti i diritti riservati.</string>
 
     <string name="auth_connect_field_hint">Connetti a</string>
     <string name="auth_connect_button">Connetti</string>

--- a/auth/src/main/res/values-nl/strings.xml
+++ b/auth/src/main/res/values-nl/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="auth_app_name">Auth Library</string>
-    <string name="auth_copyright_notice">© 2025 Hyland Software, Inc. en haar gelieerde bedrijven. Alle rechten voorbehouden.</string>
+    <string name="auth_copyright_notice">© 2026 Hyland Software, Inc. en haar gelieerde bedrijven. Alle rechten voorbehouden.</string>
 
     <string name="auth_connect_field_hint">Verbinden met</string>
     <string name="auth_connect_button">Verbinden</string>

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="auth_app_name">Auth Library</string>
-    <string name="auth_copyright_notice">© 2025 Hyland Software, Inc. and its affiliates. All rights reserved.</string>
+    <string name="auth_copyright_notice">© 2026 Hyland Software, Inc. and its affiliates. All rights reserved.</string>
 
     <string name="auth_connect_field_hint">Connect to</string>
     <string name="auth_connect_button">Connect</string>


### PR DESCRIPTION
## Summary

Updates the copyright year from **2025 → 2026** in the auth/login screen copyright notice (`auth_copyright_notice`) across **all 6 locale variants**.

Jira: [MOB-5902](https://hyland.atlassian.net/browse/MOB-5902) (Epic: ADST-876)

## Changes

Only the year changes; translated wording for each locale is preserved:

- `auth/src/main/res/values/strings.xml` (en)
- `auth/src/main/res/values-de/strings.xml`
- `auth/src/main/res/values-es/strings.xml`
- `auth/src/main/res/values-fr/strings.xml`
- `auth/src/main/res/values-it/strings.xml`
- `auth/src/main/res/values-nl/strings.xml`

## Test plan

- [ ] Launch app and verify the copyright notice on the login/auth screens shows `© 2026` across supported locales.


[MOB-5902]: https://hyland.atlassian.net/browse/MOB-5902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ