### PR TITLE
MOB-5907: Fix oversized snackbars on API 35+

### DIFF
--- a/app/src/main/res/layout/activity_ask_discovery.xml
+++ b/app/src/main/res/layout/activity_ask_discovery.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/activity_extension.xml
+++ b/app/src/main/res/layout/activity_extension.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical"
     tools:context=".activity.ExtensionActivity">
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <include layout="@layout/layout_toolbar" />

--- a/app/src/main/res/layout/activity_move.xml
+++ b/app/src/main/res/layout/activity_move.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <include layout="@layout/layout_toolbar" />

--- a/app/src/main/res/layout/activity_process.xml
+++ b/app/src/main/res/layout/activity_process.xml
@@ -5,6 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <include layout="@layout/layout_toolbar" />

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <include layout="@layout/layout_toolbar" />

--- a/auth/src/main/res/layout/activity_auth_welcome.xml
+++ b/auth/src/main/res/layout/activity_auth_welcome.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <FrameLayout
         android:id="@+id/frame_placeholder"

--- a/browse/src/main/res/layout/activity_local_preview.xml
+++ b/browse/src/main/res/layout/activity_local_preview.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar

--- a/browse/src/main/res/layout/activity_task_viewer.xml
+++ b/browse/src/main/res/layout/activity_task_viewer.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.fragment.app.FragmentContainerView

--- a/theme/src/main/res/values-night-v35/themes.xml
+++ b/theme/src/main/res/values-night-v35/themes.xml
@@ -10,7 +10,6 @@
         <!-- System bars -->
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLightStatusBar">false</item>
-        <item name="android:fitsSystemWindows">true</item>
 
     </style>
 </resources>

--- a/theme/src/main/res/values-v35/themes.xml
+++ b/theme/src/main/res/values-v35/themes.xml
@@ -6,7 +6,6 @@
         <item name="android:statusBarColor">@android:color/white</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
-        <item name="android:fitsSystemWindows">true</item>
 
     </style>
 </resources>


### PR DESCRIPTION
## MOB-5907

Fixes all snackbars rendering abnormally tall on Android 15/16 (API 35+) — e.g. the "Media scheduled for upload." confirmation occupied a large block at the bottom of the screen instead of a compact bar.

### Root cause
`MOB-5880` added `android:fitsSystemWindows="true"` at the **theme level** (`values-v35` / `values-night-v35`) to handle edge-to-edge insets on API 36. The Material `Snackbar` (`BaseTransientBottomBar.SnackbarBaseLayout`) inherits `fitsSystemWindows` from the theme and, when true, pads itself by the system-bar insets (top + bottom) — inflating every snackbar's height.

### Fix
- **Remove** the theme-level `android:fitsSystemWindows` from `values-v35` and `values-night-v35`.
- **Move** the inset handling to each non-immersive activity **root** via `android:fitsSystemWindows="true"`. This keeps content below the status bar / above the gesture bar on API 36 (where edge-to-edge is enforced and `windowOptOutEdgeToEdgeEnforcement` is ignored), without inflating snackbars — snackbars attach to `android.R.id.content`, a different view that no longer carries the flag.
- Immersive screens (capture, viewer, preview, splash) are intentionally left untouched.

### Activities updated
`activity_main`, `activity_auth_welcome`, `activity_move`, `activity_settings`, `activity_extension`, `activity_ask_discovery`, `activity_process`, `activity_share`, `activity_task_viewer`, `activity_local_preview`.

### Testing
Built and verified on the `Medium_Phone_API_36.1` (Android 16) emulator:
- ✅ Snackbar now renders as a compact single-line bar (verified with the "moved to trash" snackbar).
- ✅ Home / Personal Files, Settings — content sits correctly below the status bar (overlap resolved).
- ✅ In-app camera (`CaptureActivity`) renders correctly — no regression.

### Notes
- Build requires JDK 21 (kapt fails on JDK 25).
- No `settings.gradle` change is included (kept out intentionally).