### PR TITLE
MOB-5933: Inset preview toolbars below status bar on API 36

### DIFF
--- a/browse/src/main/res/layout/activity_local_preview.xml
+++ b/browse/src/main/res/layout/activity_local_preview.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar

--- a/capture/src/main/res/layout/activity_preview.xml
+++ b/capture/src/main/res/layout/activity_preview.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar

--- a/viewer/src/main/res/layout/activity_viewer.xml
+++ b/viewer/src/main/res/layout/activity_viewer.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar


### PR DESCRIPTION
## What

Adds `android:fitsSystemWindows="true"` to the root of the three toolbar-bearing preview activity layouts so their top app bars sit below the OS status bar under forced edge-to-edge on Android 16+ (`targetSdk 36`):

- `viewer/src/main/res/layout/activity_viewer.xml` — **`ViewerActivity`**, the node/image preview opened by tapping a file in Recent/Browse (the screen in the bug report)
- `browse/src/main/res/layout/activity_local_preview.xml` — `LocalPreviewActivity` (task/attachment preview)
- `capture/src/main/res/layout/activity_preview.xml` — capture `PreviewActivity` (post-capture review)

## Why

Bumping `targetSdk` to 36 (ADST-876 / MOB-5879) forces edge-to-edge. On Android 16 the theme still opts out via `android:windowOptOutEdgeToEdgeEnforcement`, but that flag is ignored on the next OS release, at which point every window draws under the status bar. The earlier inset work (MOB-5880 theme-level flag, MOB-5907 per-activity) covered the main navigation surfaces but bucketed the preview/viewer screens as "immersive" and left them without top insets — so the toolbar overlaps the status bar (time/battery/network) when opening an uploaded image preview.

## Fix

`fitsSystemWindows` on each root `LinearLayout` applies the system-bar insets as padding, pushing the toolbar below the status bar (and any bottom bar above the gesture nav bar). All three activities inherit `Base.Theme.Alfresco`, matching the pattern already used on the other non-immersive activities. The camera (`CaptureActivity`) and splash remain untouched.

## Testing

Verified on an **API 36 emulator with edge-to-edge enforced** (opt-out + theme-level flag temporarily removed to simulate the enforced-only OS):

- `ViewerActivity` (open an uploaded image from Recent):
  - **Before:** title collides with the status-bar clock/icons.
  - **After:** toolbar sits fully below the status bar. ✅
- Light theme; toolbar back button and overflow menu unaffected.

Screenshots captured before/after confirm the fix. The temporary theme change used only for reproduction was reverted and is **not** part of this PR.

## Notes

Enterprise (MOB-5935) is the same bug; all three layouts are shared 1:1, so it is covered by the standard Community → Enterprise merge. No enterprise-only feature involved. Note: `activity_local_preview.xml` also gets this line on the unmerged MOB-5907 branch — if that lands first, the identical one-liner will merge cleanly.

Resolves MOB-5933.