### PR TITLE
ADST-901: Bump versionName to 1.13.0 for 1.13.0 release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId "com.alfresco.content.app"
         versionCode envOrDef('VERSION_CODE', '1') as Integer
-        versionName "1.12.2"
+        versionName "1.13.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps the Android app marketing version **1.12.2 → 1.13.0** to finalise the 1.13.0 release.

## Change
- `app/build.gradle`: `versionName "1.12.2"` → `"1.13.0"` (single line)

`versionCode` is left as `envOrDef('VERSION_CODE', '1')` — the Enterprise `release-actions.yml` pipeline auto-increments it from the Play Store API at build time, so it is never committed.

Community + Enterprise are bumped together to stay in sync (paired PR in the enterprise repo). Release AABs are cut from the enterprise repo.

Jira: ADST-901