### PR TITLE
MOB-5933: Inset preview toolbars below status bar on API 36

### DIFF
--- a/browse/src/main/res/layout/activity_local_preview.xml
+++ b/browse/src/main/res/layout/activity_local_preview.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar

--- a/capture/src/main/res/layout/activity_preview.xml
+++ b/capture/src/main/res/layout/activity_preview.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar

--- a/capture/src/main/res/layout/fragment_save.xml
+++ b/capture/src/main/res/layout/fragment_save.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar

--- a/viewer/src/main/res/layout/activity_viewer.xml
+++ b/viewer/src/main/res/layout/activity_viewer.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar


### PR DESCRIPTION
## Summary

Fixes the OS status-bar overlap on all toolbar-bearing preview screens under `targetSdk 36` forced edge-to-edge.

## Root cause

Under Android 16 (targetSdk 36), the OS forces edge-to-edge: app content draws behind the status bar. Any screen whose layout root has no inset handling will render its toolbar at `y=0`, colliding with the clock/icons.

The camera "before-upload" preview screen (**`SaveFragment`** → `fragment_save.xml`) was the primary reported overlap — its `LinearLayout` root had no `fitsSystemWindows`. The viewer and local-preview screens (`activity_viewer.xml`, `activity_local_preview.xml`, `activity_preview.xml`) were in the same state.

## Fix

Add `android:fitsSystemWindows="true"` to the root of the four screens that render a toolbar, matching the pattern used by `activity_main.xml` and other content roots in the app:

| Layout | Screen | Was missing? |
|---|---|---|
| `fragment_save.xml` | SaveFragment (camera before-upload preview) | ✅ Yes — primary reported screen |
| `activity_preview.xml` | PreviewActivity (tap image in Save) | ✅ Yes |
| `activity_local_preview.xml` | LocalPreviewActivity | ✅ Yes |
| `activity_viewer.xml` | ViewerActivity | ✅ Yes |

## Verification

Verified `fragment_save.xml` fix on a physical **Pixel 7 (Android 17, 136px status bar)**:

| | Toolbar top | Title bounds | Result |
|---|---|---|---|
| Before | `y=0` | `y=35–90` (inside status bar) | back arrow overlaps clock |
| After | `y=136` | `y=171–226` (below status bar) | ✅ no overlap |

Enterprise equivalent: https://github.com/Alfresco/alfresco-mobile-workspace-android-enterprise/pull/212
